### PR TITLE
fix: resolve Pydantic and Starlette deprecation warnings

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, field_serializer
 from datetime import datetime
 from typing import List, Optional
 import uuid
@@ -22,10 +22,11 @@ class Recipe(BaseModel):
     # prep_time: int
     # cook_time: int
 
-    class Config:
-        json_encoders = {
-            datetime: lambda v: v.isoformat()
-        }
+    model_config = ConfigDict()
+    
+    @field_serializer('created_at', 'updated_at')
+    def serialize_datetime(self, value: datetime) -> str:
+        return value.isoformat()
 
 
 class RecipeCreate(BaseModel):

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -17,8 +17,7 @@ def home(request: Request, search: Optional[str] = None, message: Optional[str] 
     else:
         recipes = recipe_storage.get_all_recipes()
     
-    return templates.TemplateResponse("index.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "index.html", {
         "recipes": recipes,
         "search_query": search or "",
         "message": message
@@ -28,8 +27,7 @@ def home(request: Request, search: Optional[str] = None, message: Optional[str] 
 @router.get("/recipes/new", response_class=HTMLResponse)
 def new_recipe_form(request: Request):
     """New recipe form"""
-    return templates.TemplateResponse("recipe_form.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "recipe_form.html", {
         "recipe": None,
         "is_edit": False
     })
@@ -42,8 +40,7 @@ def recipe_detail(request: Request, recipe_id: str, message: Optional[str] = Non
     if not recipe:
         raise HTTPException(status_code=404, detail="Recipe not found")
     
-    return templates.TemplateResponse("recipe_detail.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "recipe_detail.html", {
         "recipe": recipe,
         "message": message
     })
@@ -56,8 +53,7 @@ def edit_recipe_form(request: Request, recipe_id: str):
     if not recipe:
         raise HTTPException(status_code=404, detail="Recipe not found")
     
-    return templates.TemplateResponse("recipe_form.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "recipe_form.html", {
         "recipe": recipe,
         "is_edit": True
     })
@@ -180,7 +176,6 @@ def delete_recipe_form(recipe_id: str):
 @router.get("/import", response_class=HTMLResponse)
 def import_page(request: Request, message: Optional[str] = None):
     """Import recipes page"""
-    return templates.TemplateResponse("import.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "import.html", {
         "message": message
     })

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -29,7 +29,7 @@ class RecipeStorage:
         return results
     
     def create_recipe(self, recipe_data: RecipeCreate) -> Recipe:
-        recipe = Recipe(**recipe_data.dict())
+        recipe = Recipe(**recipe_data.model_dump())
         self.recipes[recipe.id] = recipe
         return recipe
     
@@ -38,7 +38,7 @@ class RecipeStorage:
             return None
         
         recipe = self.recipes[recipe_id]
-        updated_data = recipe_data.dict()
+        updated_data = recipe_data.model_dump()
         for key, value in updated_data.items():
             setattr(recipe, key, value)
         recipe.updated_at = datetime.now()


### PR DESCRIPTION
Fixes #1 

- Replace class-based Config with ConfigDict in Recipe model
- Replace json_encoders with @field_serializer for datetime fields
- Update TemplateResponse calls to use request as first parameter
- Replace deprecated .dict() method with .model_dump() in storage service

All tests passing with no deprecation warnings.

edit11111